### PR TITLE
namespace path cases issue

### DIFF
--- a/Classes/Middleware/CreateLabelResolver.php
+++ b/Classes/Middleware/CreateLabelResolver.php
@@ -1,6 +1,6 @@
 <?php
 declare(strict_types = 1);
-namespace Sitegeist\TranslateLabels\Middleware;
+namespace Sitegeist\Translatelabels\Middleware;
 
 /**
  *


### PR DESCRIPTION
namespace Sitegeist\TranslateLabels\Middleware;  to namespace Sitegeist\Translatelabels\Middleware;
composer autoloads will now be able to load the class