### PR TITLE
set LanguageOverlayMode to hideNonTranslated to get translations from…

### DIFF
--- a/Classes/Domain/Repository/TranslationRepository.php
+++ b/Classes/Domain/Repository/TranslationRepository.php
@@ -22,6 +22,7 @@ class TranslationRepository extends \TYPO3\CMS\Extbase\Persistence\Repository
          */
         $querySettings = $this->objectManager->get(\TYPO3\CMS\Extbase\Persistence\Generic\Typo3QuerySettings::class);
         $querySettings->setRespectStoragePage(false);
+        $querySettings->setLanguageOverlayMode('hideNonTranslated');
         $this->setDefaultQuerySettings($querySettings);
     }
 


### PR DESCRIPTION
if we have:
- default language English
- and first language German (sys_language_uid=1)
- and the siteconfig for German is set to `fallbackType: fallback` 
- and we translate the label 'example' in the Database only in english
We get the English label in the Frontend.

But we want the German Label from the XLF file.

With this change we ignore the fallbackType and always use the fallback form the XLF