### PR TITLE
Implemented a file cache for labels to avoid multiple db requests

### DIFF
--- a/Classes/Domain/Model/Translation.php
+++ b/Classes/Domain/Model/Translation.php
@@ -42,8 +42,14 @@ class Translation extends AbstractEntity
      */
     protected $l10n_parent = 0;
 
+    /**
+     * @var int
+     */
     protected $starttime = 0;
 
+    /**
+     * @var int
+     */
     protected $endtime = 0;
 
     /**

--- a/Classes/Domain/Model/Translation.php
+++ b/Classes/Domain/Model/Translation.php
@@ -42,6 +42,10 @@ class Translation extends AbstractEntity
      */
     protected $l10n_parent = 0;
 
+    protected $starttime = 0;
+
+    protected $endtime = 0;
+
     /**
      * Returns the labelkey
      *
@@ -134,5 +138,25 @@ class Translation extends AbstractEntity
     public function setL10nParent($l10nParent)
     {
         $this->l10n_parent = $l10nParent;
+    }
+
+    public function getStarttime(): int
+    {
+        return $this->starttime;
+    }
+
+    public function setStarttime(int $starttime): void
+    {
+        $this->starttime = $starttime;
+    }
+
+    public function getEndtime(): int
+    {
+        return $this->endtime;
+    }
+
+    public function setEndtime(int $endtime): void
+    {
+        $this->endtime = $endtime;
     }
 }

--- a/Classes/Domain/Repository/TranslationRepository.php
+++ b/Classes/Domain/Repository/TranslationRepository.php
@@ -81,4 +81,24 @@ class TranslationRepository extends Repository
         $result = $query->matching($constraints)->execute();
         return $result->getFirst();
     }
+
+    public function findAllByPid(int $pid)
+    {
+        $query = $this->createQuery();
+
+        $query->getQuerySettings()
+            ->setRespectSysLanguage(false)
+            ->setLanguageOverlayMode(false)
+            ->setRespectStoragePage(false);
+
+        $constraints = $query->logicalAnd(
+            [
+                $query->equals('pid', $pid),
+                $query->equals('hidden', false)
+            ]
+        );
+
+        $result = $query->matching($constraints)->execute();
+        return $result;
+    }
 }

--- a/Classes/Domain/Repository/TranslationRepository.php
+++ b/Classes/Domain/Repository/TranslationRepository.php
@@ -89,6 +89,8 @@ class TranslationRepository extends Repository
         $query->getQuerySettings()
             ->setRespectSysLanguage(false)
             ->setLanguageOverlayMode(false)
+            ->setIgnoreEnableFields(true)
+            ->setEnableFieldsToBeIgnored(['starttime', 'endtime'])
             ->setRespectStoragePage(false);
 
         $constraints = $query->logicalAnd(

--- a/Classes/Hooks/UpdateLabelsHook.php
+++ b/Classes/Hooks/UpdateLabelsHook.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Sitegeist\Translatelabels\Hooks;
+
+
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use Sitegeist\Translatelabels\Renderer\FrontendRenderer;
+use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
+use Sitegeist\Translatelabels\Exception\LabelReplaceException;
+use Sitegeist\Translatelabels\Utility\TranslationLabelUtility;
+use TYPO3\CMS\Backend\Routing\Exception\RouteNotFoundException;
+
+
+class UpdateLabelsHook
+{
+    public function processDatamap_afterDatabaseOperations($status, $table, $id, array $fieldArray, DataHandler $dataHandler)
+    {
+        if ($table === 'tx_translatelabels_domain_model_translation') {
+            $cache = GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('translatelabels_cache');
+            $cache->flush();
+        }
+    }
+}

--- a/Classes/Utility/TranslationLabelUtility.php
+++ b/Classes/Utility/TranslationLabelUtility.php
@@ -10,6 +10,13 @@ namespace Sitegeist\Translatelabels\Utility;
  * LICENSE file that was distributed with this source code.
  *
  */
+
+use Kanti\ServerTiming\Utility\TimingUtility;
+use phpDocumentor\Reflection\Types\This;
+use TYPO3\CMS\Core\Cache\Backend\BackendInterface;
+use TYPO3\CMS\Core\Cache\Backend\FileBackend;
+use TYPO3\CMS\Core\Cache\Backend\SimpleFileBackend;
+use TYPO3\CMS\Core\Cache\CacheManager;
 use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Http\ApplicationType;
@@ -25,6 +32,8 @@ use TYPO3\CMS\Adminpanel\Service\ConfigurationService;
 
 class TranslationLabelUtility
 {
+    protected static ?array $labelCache = null;
+    protected static int $languageUid = 0;
     /**
      * returns storagePid where to store translation records
      *
@@ -56,32 +65,79 @@ class TranslationLabelUtility
     {
         $translation = self::getLabelFromDatabase($labelKey, self::getStoragePid());
         if ($translation !== null) {
-            $fallBackTranslation = $translation->getTranslation();
+            $fallBackTranslation = $translation;
+//            $fallBackTranslation = $translation->getTranslation();
         }
         return $fallBackTranslation;
     }
 
     /**
-     * @param string $labelKey         Translation Key
-     * @param int $pid                 pid of sysfolder where to search for translation records (needed for calls from BE)
-     * @param int | null $languageUid  uid of language of translation label, null means current language
-
+     * @param string $labelKey Translation Key
+     * @param int $pid pid of sysfolder where to search for translation records (needed for calls from BE)
+     * @param int | null $languageUid uid of language of translation label, null means current language
      * @return object                  translation from database or null if it doesn't exist
      * @throws \TYPO3\CMS\Extbase\Object\Exception
      */
     public static function getLabelFromDatabase(string $labelKey, int $pid, int $languageUid = null)
     {
-        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
-        /**
-         * @var $translationRepository TranslationRepository
-         */
-        $translationRepository = $objectManager->get(TranslationRepository::class);
-        if ($languageUid === null) {
-            $translation = $translationRepository->findOneByLabelKeyInPid($labelKey, $pid);
-        } else {
-            $translation = $translationRepository->findOneByLabelKeyInLanguageInPid($labelKey, $languageUid, $pid);
+        $stop = TimingUtility::stopWatch('getLabelFromDatabase');
+
+        if (!self::$labelCache) {
+
+            $cache ??= GeneralUtility::makeInstance(\TYPO3\CMS\Core\Cache\CacheManager::class)->getCache('translatelabels_cache');
+            $cacheIdentifier = (string)$pid;
+
+            $cacheValue = $cache->require($cacheIdentifier);
+            if ($cacheValue === false) {
+                $stop2 = TimingUtility::stopWatch('createLabelCache', $cacheIdentifier);
+
+                $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+                /**
+                 * @var $translationRepository TranslationRepository
+                 */
+                $translationRepository = $objectManager->get(TranslationRepository::class);
+                $cacheLifetime = PHP_INT_MAX;
+                $result = $translationRepository->findAllByPid($pid)->toArray();
+                $cacheValue = [];
+                /** @var Translation $translation */
+                foreach ($result as $translation) {
+                    $cacheValue[$translation->getLabelkey()][$translation->getLanguageUid()] = $translation->getTranslation();
+                    if ($translation->getStarttime() > $GLOBALS['EXEC_TIME']) {
+                        $cacheLifetime = min($cacheLifetime, $translation->getStarttime());
+                    }
+                    if ($translation->getEndtime() > $GLOBALS['EXEC_TIME']) {
+                        $cacheLifetime = min($cacheLifetime, $translation->getEndtime());
+                    }
+                }
+                $cache->set($cacheIdentifier,'return ' . var_export($cacheValue, true) . ';', [], $cacheLifetime !== PHP_INT_MAX ? ($cacheLifetime - $GLOBALS['EXEC_TIME']) : 0);
+                $stop2();
+            }
+            self::$labelCache = $cacheValue;
         }
-        return $translation;
+
+        if (!self::$languageUid && !$languageUid) {
+            $context = GeneralUtility::makeInstance(Context::class);
+            self::$languageUid = $context->getPropertyFromAspect('language', 'id');
+        }
+
+        $stop();
+
+        return self::$labelCache[$labelKey][$languageUid ?? self::$languageUid] ?? self::$labelCache[$labelKey][-1] ?? null;
+
+
+//        $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
+//        /**
+//         * @var $translationRepository TranslationRepository
+//         */
+//        $translationRepository = $objectManager->get(TranslationRepository::class);
+//
+//        if ($languageUid === null) {
+//            $translation = $translationRepository->findOneByLabelKeyInPid($labelKey, $pid);
+//        } else {
+//            $translation = $translationRepository->findOneByLabelKeyInLanguageInPid($labelKey, $languageUid, $pid);
+//        }
+//        $stop();
+//        return $translation;
     }
 
     /**

--- a/Classes/Utility/TranslationLabelUtility.php
+++ b/Classes/Utility/TranslationLabelUtility.php
@@ -11,7 +11,6 @@ namespace Sitegeist\Translatelabels\Utility;
  *
  */
 
-use Kanti\ServerTiming\Utility\TimingUtility;
 use phpDocumentor\Reflection\Types\This;
 use TYPO3\CMS\Core\Cache\Backend\BackendInterface;
 use TYPO3\CMS\Core\Cache\Backend\FileBackend;

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -48,4 +48,11 @@ call_user_func(function () {
 
     $GLOBALS['TYPO3_CONF_VARS']['FE']['eID_include']['translatelabels_translate']
         = \Sitegeist\Translatelabels\Controller\AjaxController::class . '::saveDataAction';
+
+
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['translatelabels_cache'] ??= [];
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['translatelabels_cache']['backend'] ??= \TYPO3\CMS\Core\Cache\Backend\FileBackend::class;
+    $GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations']['translatelabels_cache']['frontend'] ??= \TYPO3\CMS\Core\Cache\Frontend\PhpFrontend::class;
+
+    $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['t3lib/class.t3lib_tcemain.php']['processDatamapClass'][] = \Sitegeist\Translatelabels\Hooks\UpdateLabelsHook::class;
 });


### PR DESCRIPTION
we implemented a file caching in the readLableFromDatabase function to avoid multiple DB requests.

- With approx 300 labels in the project the function took around 1 sec.
- After the caching, time was reduced to 1 ms.