### PR TITLE
Extendable conditions for translation labels

### DIFF
--- a/Classes/Event/CheckedRenderingConditionsEvent.php
+++ b/Classes/Event/CheckedRenderingConditionsEvent.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Sitegeist\Translatelabels\Event;
+
+final class CheckedRenderingConditionsEvent
+{
+    private bool $showTranslationLabels;
+    private string $labelKey;
+    private string $extensionName;
+
+    public function __construct(
+        bool $showTranslationLabels,
+        string $labelKey,
+        string $extensionName
+    ) {
+        $this->showTranslationLabels = $showTranslationLabels;
+        $this->labelKey = $labelKey;
+        $this->extensionName = $extensionName;
+    }
+
+    public function getShowTranslationLabels(): bool
+    {
+        return $this->showTranslationLabels;
+    }
+
+    public function setShowTranslationLabels(bool $showTranslationLabels): void
+    {
+        $this->showTranslationLabels = $showTranslationLabels;
+    }
+
+    public function getLabelKey(): string
+    {
+        return $this->labelKey;
+    }
+
+    public function getExtensionName(): string
+    {
+        return $this->extensionName;
+    }
+}

--- a/Classes/Event/CheckedRenderingConditionsEvent.php
+++ b/Classes/Event/CheckedRenderingConditionsEvent.php
@@ -4,20 +4,25 @@ declare(strict_types=1);
 
 namespace Sitegeist\Translatelabels\Event;
 
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
+
 final class CheckedRenderingConditionsEvent
 {
     private bool $showTranslationLabels;
     private string $labelKey;
     private string $extensionName;
+    private ?RenderingContextInterface $renderingContext;
 
     public function __construct(
         bool $showTranslationLabels,
         string $labelKey,
-        string $extensionName
+        string $extensionName,
+        RenderingContextInterface $renderingContext = null
     ) {
         $this->showTranslationLabels = $showTranslationLabels;
         $this->labelKey = $labelKey;
         $this->extensionName = $extensionName;
+        $this->renderingContext = $renderingContext;
     }
 
     public function getShowTranslationLabels(): bool
@@ -38,5 +43,10 @@ final class CheckedRenderingConditionsEvent
     public function getExtensionName(): string
     {
         return $this->extensionName;
+    }
+
+    public function getRenderingContext(): ?RenderingContextInterface
+    {
+        return $this->renderingContext;
     }
 }

--- a/Classes/Hooks/TypoScriptFrontendController.php
+++ b/Classes/Hooks/TypoScriptFrontendController.php
@@ -39,7 +39,7 @@ class TypoScriptFrontendController
         array &$params,
         \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $ref
     ) {
-        if ($ref->isINTincScript() || !TranslationLabelUtility::isFrontendWithLoggedInBEUser()) {
+        if ($ref->isINTincScript() || !TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation()) {
             return;
         }
 

--- a/Classes/Middleware/ReplaceLabels.php
+++ b/Classes/Middleware/ReplaceLabels.php
@@ -30,7 +30,7 @@ class ReplaceLabels implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
         $response = $handler->handle($request);
-        if (!$GLOBALS['TSFE']->isINTincScript() || $response instanceof NullResponse || !TranslationLabelUtility::isFrontendWithLoggedInBEUser()) {
+        if (!$GLOBALS['TSFE']->isINTincScript() || $response instanceof NullResponse || !TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation()) {
             return $response;
         }
 

--- a/Classes/Plugin/FrontendLoginController.php
+++ b/Classes/Plugin/FrontendLoginController.php
@@ -86,7 +86,7 @@ class FrontendLoginController extends \TYPO3\CMS\Felogin\Controller\FrontendLogi
         $id =  TranslationLabelUtility::getLabelKeyWithoutPrefixes($this->languageFilePath . ':' . $key);
 
         $label = TranslationLabelUtility::readLabelFromDatabase($id, $label);
-        if (TranslationLabelUtility::isFrontendWithLoggedInBEUser($id)) {
+        if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id)) {
             $label = TranslationLabelUtility::renderTranslationWithExtendedInformation($id, $label, $this->prefixId);
         }
 

--- a/Classes/Utility/TranslationLabelUtility.php
+++ b/Classes/Utility/TranslationLabelUtility.php
@@ -24,6 +24,7 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 use TYPO3\CMS\Core\Context\Context;
 use Sitegeist\Translatelabels\Domain\Repository\TranslationRepository;
 use TYPO3\CMS\Adminpanel\Service\ConfigurationService;
+use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 
 class TranslationLabelUtility
 {
@@ -140,10 +141,11 @@ class TranslationLabelUtility
     /**
      * @param string $labelKey
      * @param string $extensionName
+     * @param RenderingContextInterface $renderingContext
      * @return bool
      * @throws AspectNotFoundException
      */
-    public static function meetsRenderingConditionsForExtendedInformation($labelKey = '', $extensionName = '')
+    public static function meetsRenderingConditionsForExtendedInformation($labelKey = '', $extensionName = '', $renderingContext = null)
     {
         if (!$labelKey) {
             $labelKey = '';
@@ -157,10 +159,12 @@ class TranslationLabelUtility
         $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
         /** @var CheckedRenderingConditionsEvent $event */
         $event = $eventDispatcher->dispatch(
-            new CheckedRenderingConditionsEvent($showTranslationLabels, $labelKey, $extensionName)
+            new CheckedRenderingConditionsEvent($showTranslationLabels, $labelKey, $extensionName, $renderingContext)
         );
 
-        return $event->getShowTranslationLabels();
+        $showTranslationLabels = $event->getShowTranslationLabels();
+
+        return $showTranslationLabels;
     }
 
     /**

--- a/Classes/Utility/TranslationLabelUtility.php
+++ b/Classes/Utility/TranslationLabelUtility.php
@@ -14,7 +14,9 @@ use TYPO3\CMS\Extbase\Persistence\Exception\IllegalObjectTypeException;
 use TYPO3\CMS\Core\Context\Exception\AspectNotFoundException;
 use TYPO3\CMS\Core\Http\ApplicationType;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Sitegeist\Translatelabels\Domain\Model\Translation;
+use Sitegeist\Translatelabels\Event\CheckedRenderingConditionsEvent;
 use TYPO3\CMS\Backend\Exception;
 use TYPO3\CMS\Core\Http\ServerRequestFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -142,6 +144,32 @@ class TranslationLabelUtility
      * @throws AspectNotFoundException
      */
     public static function meetsRenderingConditionsForExtendedInformation($labelKey = '', $extensionName = '')
+    {
+        if (!$labelKey) {
+            $labelKey = '';
+        }
+        if (!$extensionName) {
+            $extensionName = '';
+        }
+
+        $showTranslationLabels = self::checkRenderingConditionsForExtendedInformation($labelKey, $extensionName);
+
+        $eventDispatcher = GeneralUtility::makeInstance(EventDispatcherInterface::class);
+        /** @var CheckedRenderingConditionsEvent $event */
+        $event = $eventDispatcher->dispatch(
+            new CheckedRenderingConditionsEvent($showTranslationLabels, $labelKey, $extensionName)
+        );
+
+        return $event->getShowTranslationLabels();
+    }
+
+    /**
+     * @param string $labelKey
+     * @param string $extensionName
+     * @return bool
+     * @throws AspectNotFoundException
+     */
+    private static function checkRenderingConditionsForExtendedInformation($labelKey, $extensionName)
     {
         $showTranslationLabels = false;
 

--- a/Classes/Utility/TranslationLabelUtility.php
+++ b/Classes/Utility/TranslationLabelUtility.php
@@ -141,7 +141,7 @@ class TranslationLabelUtility
      * @return bool
      * @throws AspectNotFoundException
      */
-    public static function isFrontendWithLoggedInBEUser($labelKey = '', $extensionName = '')
+    public static function meetsRenderingConditionsForExtendedInformation($labelKey = '', $extensionName = '')
     {
         $showTranslationLabels = false;
 

--- a/Classes/ViewHelpers/Traits/RenderTranslation.php
+++ b/Classes/ViewHelpers/Traits/RenderTranslation.php
@@ -31,8 +31,12 @@ trait RenderTranslation
         return $array;
     }
 
-    public static function renderTranslation(string $translationKey, string $value, array $translateArguments)
-    {
+    public static function renderTranslation(
+        string $translationKey,
+        string $value,
+        array $translateArguments,
+        RenderingContextInterface $renderingContext = null
+    ) {
 
         if (ApplicationType::fromRequest($GLOBALS['TYPO3_REQUEST'])->isFrontend() && $value !== '') {
             // language files in chain of form framework are without LLL:, all others use this prefix
@@ -47,7 +51,7 @@ trait RenderTranslation
                     count($translateArguments)
                 );
             }
-            if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id)) {
+            if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id, '', $renderingContext)) {
                 $value = TranslationLabelUtility::renderTranslationWithExtendedInformation(
                     $id,
                     $value,

--- a/Classes/ViewHelpers/Traits/RenderTranslation.php
+++ b/Classes/ViewHelpers/Traits/RenderTranslation.php
@@ -47,7 +47,7 @@ trait RenderTranslation
                     count($translateArguments)
                 );
             }
-            if (TranslationLabelUtility::isFrontendWithLoggedInBEUser($id)) {
+            if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id)) {
                 $value = TranslationLabelUtility::renderTranslationWithExtendedInformation(
                     $id,
                     $value,

--- a/Classes/ViewHelpers/TranslateElementErrorViewHelper.php
+++ b/Classes/ViewHelpers/TranslateElementErrorViewHelper.php
@@ -70,6 +70,6 @@ class TranslateElementErrorViewHelper extends \TYPO3\CMS\Form\ViewHelpers\Transl
         if ($originalTranslation === '') {
             $originalTranslation = $defaultValue;
         }
-        return self::renderTranslation($translationKey, $originalTranslation, $errorArguments);
+        return self::renderTranslation($translationKey, $originalTranslation, $errorArguments, $renderingContext);
     }
 }

--- a/Classes/ViewHelpers/TranslateElementPropertyViewHelper.php
+++ b/Classes/ViewHelpers/TranslateElementPropertyViewHelper.php
@@ -142,11 +142,12 @@ class TranslateElementPropertyViewHelper extends \TYPO3\CMS\Form\ViewHelpers\Tra
                     $ret[$key] = self::renderTranslation(
                         $translationKey . '.' . $key,
                         (string)$value,
-                        $translationArguments
+                        $translationArguments,
+                        $renderingContext
                     );
                 }
             } else {
-                $ret = self::renderTranslation($translationKey, $ret, $translationArguments);
+                $ret = self::renderTranslation($translationKey, $ret, $translationArguments, $renderingContext);
             }
         } elseif (\is_array($property) && $property[0] === 'items') {
             // new parameter: options is array auf key-value pairs
@@ -161,7 +162,7 @@ class TranslateElementPropertyViewHelper extends \TYPO3\CMS\Form\ViewHelpers\Tra
                     'options',
                     $key
                 );
-                $ret[$key] = self::renderTranslation($translationKey, $value, $translationArguments);
+                $ret[$key] = self::renderTranslation($translationKey, $value, $translationArguments, $renderingContext);
             }
         } elseif ($propertyType === 'renderingOptions') {
             // for buttons, $property can be 'previousButtonLabel' or 'nextButtonLabel' or 'submitButtonLabel'
@@ -173,7 +174,7 @@ class TranslateElementPropertyViewHelper extends \TYPO3\CMS\Form\ViewHelpers\Tra
                 $propertyType,
                 $property
             );
-            $ret = self::renderTranslation($translationKey, $ret, $translationArguments);
+            $ret = self::renderTranslation($translationKey, $ret, $translationArguments, $renderingContext);
         }
         return $ret;
     }

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -143,7 +143,7 @@ class TranslateViewHelper extends AbstractViewHelper
             if (\is_array($translateArguments) && $value !== null) {
                 $value = sprintf($value, ...array_values($translateArguments)) ?: sprintf('Error: could not translate key "%s" with value "%s" and %d argument(s)!', $key, $value, count($translateArguments));
             }
-            if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id, $extensionName)) {
+            if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id, $extensionName, $renderingContext)) {
                 $value = TranslationLabelUtility::renderTranslationWithExtendedInformation($id, $value, $extensionName, $translateArguments, $arguments['languageKey'], $arguments['alternativeLanguageKeys']);
             }
         }

--- a/Classes/ViewHelpers/TranslateViewHelper.php
+++ b/Classes/ViewHelpers/TranslateViewHelper.php
@@ -143,7 +143,7 @@ class TranslateViewHelper extends AbstractViewHelper
             if (\is_array($translateArguments) && $value !== null) {
                 $value = sprintf($value, ...array_values($translateArguments)) ?: sprintf('Error: could not translate key "%s" with value "%s" and %d argument(s)!', $key, $value, count($translateArguments));
             }
-            if (TranslationLabelUtility::isFrontendWithLoggedInBEUser($id, $extensionName)) {
+            if (TranslationLabelUtility::meetsRenderingConditionsForExtendedInformation($id, $extensionName)) {
                 $value = TranslationLabelUtility::renderTranslationWithExtendedInformation($id, $value, $extensionName, $translateArguments, $arguments['languageKey'], $arguments['alternativeLanguageKeys']);
             }
         }


### PR DESCRIPTION
Translation labels are shown when the admin panel is active and _Show translation labels_ is enabled and some other checks. 

With these changes an event is dispatched after the basic checks are walked through.

The Event provides `labelKey`, `extensionName` and the current `renderingContext`.