### PR TITLE
[BUGFIX] #93781 Add pointer-events again if parent prevents pointer-events

### DIFF
--- a/Resources/Public/Css/style.css
+++ b/Resources/Public/Css/style.css
@@ -22,6 +22,7 @@ div.translatelabels-ok-response {
 
 span.translatelabels-tooltip {
     border-bottom: 1px dashed red !important;
+    pointer-events: auto;
 }
 
 span.translatelabels-tooltip-inner {


### PR DESCRIPTION
If a parent of a label prevents pointer-events by ` pointer-events: none` the tool-tip should get the default behaviour